### PR TITLE
Fix receiving big replies

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -542,7 +542,7 @@ func (c *Conn) recvLoop(conn net.Conn) error {
 
 		blen := int(binary.BigEndian.Uint32(buf[:4]))
 		if cap(buf) < blen {
-			buf = make([]byte, blen)
+			buf = make([]byte, blen+16)
 		}
 
 		_, err = io.ReadFull(conn, buf[:blen])


### PR DESCRIPTION
When current buffer is not big enough for response - new buffer is allocated with size of the response. Then we decode header into first 16 bytes and rest of the response into slice from 16 to 16 + blen position. But size of the whole slice is just blen and this panics on slice index out of bound.